### PR TITLE
Workflow enhancements

### DIFF
--- a/app/views/rails_admin/main/_globalize_field.haml
+++ b/app/views/rails_admin/main/_globalize_field.haml
@@ -3,33 +3,33 @@
 
 .control-group{:class=>("#{field.css_class} #{field.type}_type #{'error' if in_error}")}
   .controls{:class => field.type.eql?('text') ? 'well' : ''}
-    - if field.type == :text
+    - if [:text, :ck_editor, :code_mirror, :wysihtml5].include? field.type
       :ruby
-        if field.ckeditor
+        if field.type == :ck_editor
           richtext = 'ckeditor'
           js_data = {
-            :jspath => field.ckeditor_location ? field.ckeditor_location : field.ckeditor_base_location + "ckeditor.js",
-            :base_location => field.ckeditor_base_location,
+            :jspath => field.location ? field.location : field.base_location + "ckeditor.js",
+            :base_location => field.base_location,
             :options => {
-              :customConfig => field.ckeditor_config_js ? field.ckeditor_config_js : field.ckeditor_base_location + "config.js"
+              :customConfig => field.config_js ? field.config_js : field.base_location + "config.js"
             }
           }
-        elsif field.codemirror
+        elsif field.type == :code_mirror
           richtext = 'codemirror'
           js_data = {
-            :csspath => field.codemirror_css_location,
-            :jspath => field.codemirror_js_location,
-            :options => field.codemirror_config,
-            :locations => field.codemirror_assets
+            :csspath => field.css_location,
+            :jspath => field.js_location,
+            :options => field.config,
+            :locations => field.assets
           }
-        elsif field.bootstrap_wysihtml5
+        elsif field.type == :wysihtml5
           richtext = 'bootstrap-wysihtml5'
           js_data = {
-            :csspath => field.bootstrap_wysihtml5_css_location,
-            :jspath => field.bootstrap_wysihtml5_js_location,
-            :config_options => field.bootstrap_wysihtml5_config_options.to_json
+            :csspath => field.css_location,
+            :jspath => field.js_location,
+            :config_options => field.config_options.to_json
           }
-        elsif field.respond_to?(:rich) && field.rich
+        elsif field.respond_to?(:rich) && field.type == :rich
           richtext = 'rich'
         else
           richtext = false

--- a/app/views/rails_admin/main/_globalize_field.haml
+++ b/app/views/rails_admin/main/_globalize_field.haml
@@ -45,6 +45,9 @@
       = render :partial => "file_upload", :locals => { form: form, field: field } #if false
       =# link_to("EDIT", rails_admin.edit_path(object.class.to_s.gsub("::","~").underscore,object.id), :target=>"_blank")
 
+    - elsif field.type == :datetime
+      = render :partial => "rails_admin/main/form_datetime", :locals => { form: form, field: field }
+
     - else
       = form.send(field.view_helper, field.method_name, field.html_attributes)
 

--- a/app/views/rails_admin/main/globalize.html.haml
+++ b/app/views/rails_admin/main/globalize.html.haml
@@ -31,7 +31,7 @@
             = raw @object.send(t)
 
       .span8
-        - I18n.with_locale target_locale do
+        - Globalize.with_locale target_locale do
           = render :partial => "globalize_field", :locals => { :object => @object, :form => form, :field => rails_admin_fields[t] }
 
   - if @associated_translations
@@ -55,7 +55,7 @@
                     .original-content= raw obj.send(t)
 
                 .span8
-                  - I18n.with_locale target_locale do
+                  - Globalize.with_locale target_locale do
                     = render :partial => "globalize_field", :locals => {:field => field, :object => obj, :form => subform}
 
           - @sub_associated_translations = collection.first.class.associated_model_to_globalize rescue nil
@@ -80,7 +80,7 @@
                             .original-content= raw sub_obj.send(t)
 
                         .span8
-                          - I18n.with_locale target_locale do
+                          - Globalize.with_locale target_locale do
                             = render :partial => "globalize_field", :locals => {:field => field, :object => sub_obj, :form => subsubform}
 
             - if @sub_associated_translations[:has_one].present?

--- a/app/views/rails_admin/main/globalize.html.haml
+++ b/app/views/rails_admin/main/globalize.html.haml
@@ -21,7 +21,7 @@
 %p= raw I18n.translate("admin.actions.globalize.subtitle", :locale_name => "<strong>#{I18n.locale}</strong>".upcase)
 
 = rails_admin_form_for @object, :url => rails_admin.globalize_path(@abstract_model, @object.id), :as => @abstract_model.param_key, :html => {:multipart => true, :class => 'globalize-form'} do |form|
-  = select_tag 'target_locale', options_for_select(  @available_locales, @target_locale ), :id => "target_locale_select", :"data-target-url" => rails_admin.globalize_path(@object.class.to_s.split("::").map(&:underscore).join("~"), @object.id)
+  = select_tag 'target_locale', grouped_options_for_select([["Already Translated",  @already_translated_locales], ["Not-Yet-Translated", @not_yet_translated_locales]], @target_locale), :id => "target_locale_select", :"data-target-url" => rails_admin.globalize_path(@object.class.to_s.split("::").map(&:underscore).join("~"), @object.id)
   - rails_admin_fields.keys.each do |t|
     %h5 #{@object.class.human_attribute_name(t.to_sym)}:
     .row-fluid

--- a/lib/rails_admin_globalize.rb
+++ b/lib/rails_admin_globalize.rb
@@ -48,7 +48,6 @@ module RailsAdmin
               loc = @current_locale = I18n.locale
               I18n.locale = @target_locale = params[:target_locale]
 
-              satisfy_strong_params!
               sanitize_params_for!(:update)
 
               @object.set_attributes(params[@abstract_model.param_key])

--- a/lib/rails_admin_globalize.rb
+++ b/lib/rails_admin_globalize.rb
@@ -40,6 +40,9 @@ module RailsAdmin
           Proc.new do
             @available_locales = (I18n.available_locales - [I18n.locale])
             @available_locales = @object.available_locales if @object.respond_to?("available_locales")
+            @already_translated_locales = []
+            @already_translated_locales = @object.translated_locales.map(&:to_s) if @object.respond_to?("translated_locales")
+            @not_yet_translated_locales = @available_locales - @already_translated_locales
 
             if request.get?
               @target_locale = params[:target_locale] || @available_locales.first || I18n.locale


### PR DESCRIPTION
This builds upon my other PR (#10), adding a pair of enhancements that we have found useful

The first is splitting up the available locales into 2 groups: already_translated and not_yet_translated. I use optgroups to display them cleanly.
The second is the addition of the datetime field type (our translations each have their own `published_at` field, which this drives)

Please let me know if you have any questions.

-Ben
