### PR TITLE
fixes not yet translated locales

### DIFF
--- a/lib/rails_admin_globalize.rb
+++ b/lib/rails_admin_globalize.rb
@@ -38,10 +38,15 @@ module RailsAdmin
         register_instance_option :controller do
 
           Proc.new do
-            @available_locales = (I18n.available_locales - [I18n.locale])
-            @available_locales = @object.available_locales if @object.respond_to?("available_locales")
-            @already_translated_locales = []
-            @already_translated_locales = @object.translated_locales.map(&:to_s) if @object.respond_to?("translated_locales")
+            @available_locales = (I18n.available_locales - [I18n.locale]).map(&:to_s)
+
+            @already_translated_locales =
+              if @object.respond_to? 'translated_locales'
+                @object.translated_locales.map(&:to_s)
+              else
+                []
+              end
+
             @not_yet_translated_locales = @available_locales - @already_translated_locales
 
             if request.get?


### PR DESCRIPTION
Apparently, `object.available_locales` only returns translated fields for the specified object.

``` rb
[1] pry(main)> I18n.default_locale
=> :it
[2] pry(main)> I18n.available_locales
=> [:it, :en, :de]
[3] pry(main)> Page.first.available_locales
  Page Load (0.3ms)  SELECT  `pages`.* FROM `pages`   ORDER BY `pages`.`id` ASC LIMIT 1
  Page::Translation Load (0.3ms)  SELECT `page_translations`.* FROM `page_translations`  WHERE `page_translations`.`page_id` = 1
=> [:it]
```

So in the globalize panel you will never see the "en" and "de" options to translate.

This PR does not use object.available_locales and also maps `@available_locales` to strings for a proper execution of `@not_yet_translated_locales = @available_locales - @already_translated_locales`
